### PR TITLE
ECC Marshaler Encoding

### DIFF
--- a/signing-service-challenge-go/crypto/ecdsa.go
+++ b/signing-service-challenge-go/crypto/ecdsa.go
@@ -28,7 +28,7 @@ func (m ECCMarshaler) Encode(keyPair ECCKeyPair) ([]byte, []byte, error) {
 		return nil, nil, err
 	}
 
-	publicKeyBytes, err := x509.MarshalPKIXPublicKey(&keyPair.Public)
+	publicKeyBytes, err := x509.MarshalPKIXPublicKey(keyPair.Public)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/signing-service-challenge-go/go.mod
+++ b/signing-service-challenge-go/go.mod
@@ -1,5 +1,3 @@
 module github.com/fiskaly/coding-challenges/signing-service-challenge
 
 go 1.20
-
-require github.com/google/uuid v1.3.0


### PR DESCRIPTION
This PR provides the following changes:

* fixes the ECC Marshaler Encode method by providing the correct reference to the public key