### PR TITLE
Implement signature device creation and signing

### DIFF
--- a/signing-service-challenge-go/Makefile
+++ b/signing-service-challenge-go/Makefile
@@ -1,0 +1,15 @@
+.PHONY: all build test run clean
+
+all: test build
+
+build:
+	go build -o signing-service-challenge .
+
+test:
+	go test ./... -v -race
+
+run: build
+	./signing-service-challenge
+
+clean:
+	rm -f signing-service-challenge

--- a/signing-service-challenge-go/api/device.go
+++ b/signing-service-challenge-go/api/device.go
@@ -1,3 +1,210 @@
 package api
 
-// TODO: REST endpoints ...
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/fiskaly/coding-challenges/signing-service-challenge/domain"
+	"github.com/fiskaly/coding-challenges/signing-service-challenge/persistence"
+)
+
+var uuidRegex = regexp.MustCompile("^[a-fA-F0-9-]{36}$")
+
+type CreateSignatureDeviceRequest struct {
+	Algorithm string `json:"algorithm"`
+	Label     string `json:"label,omitempty"`
+}
+
+type CreateSignatureDeviceResponse struct {
+	ID               string `json:"id"`
+	Algorithm        string `json:"algorithm"`
+	Label            string `json:"label,omitempty"`
+	SignatureCounter int    `json:"signature_counter"`
+}
+
+type SignatureRequest struct {
+	Data string `json:"data"`
+}
+
+type SignatureResponse struct {
+	Signature  string `json:"signature"`
+	SignedData string `json:"signed_data"`
+}
+
+type DeviceHandler struct {
+	store persistence.Storage
+}
+
+func NewDeviceHandler(store persistence.Storage) *DeviceHandler {
+	return &DeviceHandler{store: store}
+}
+
+func (h *DeviceHandler) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/api/v0/devices", h.HandleDevices)
+	mux.HandleFunc("/api/v0/devices/", h.HandleDeviceActions)
+}
+
+func (h *DeviceHandler) HandleDevices(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		h.CreateSignatureDevice(w, r)
+	case http.MethodGet:
+		h.ListDevices(w, r)
+	default:
+		WriteErrorResponse(w, http.StatusMethodNotAllowed, []string{"Method not allowed"})
+	}
+}
+
+func (h *DeviceHandler) HandleDeviceActions(w http.ResponseWriter, r *http.Request) {
+	id := strings.TrimPrefix(r.URL.Path, "/api/v0/devices/")
+	id = strings.Split(id, "/")[0]
+
+	if !uuidRegex.MatchString(id) && id != "" {
+		WriteErrorResponse(w, http.StatusBadRequest, []string{"Invalid device ID format"})
+		return
+	}
+
+	switch {
+	case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/sign"):
+		h.SignTransaction(w, r, id)
+	case r.Method == http.MethodGet && id != "":
+		h.GetDeviceDetails(w, r, id)
+	default:
+		WriteErrorResponse(w, http.StatusNotFound, []string{"Endpoint not found"})
+	}
+}
+
+func (h *DeviceHandler) CreateSignatureDevice(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		WriteErrorResponse(w, http.StatusMethodNotAllowed, []string{"Method not allowed"})
+		return
+	}
+
+	var req CreateSignatureDeviceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		WriteErrorResponse(w, http.StatusBadRequest, []string{"Invalid request payload"})
+		return
+	}
+	if req.Algorithm != "RSA" && req.Algorithm != "ECC" {
+		WriteErrorResponse(w, http.StatusBadRequest, []string{"Unsupported algorithm"})
+		return
+	}
+
+	req.Label = sanitizeLabel(req.Label)
+	device, err := domain.CreateNewDevice(req.Algorithm, req.Label)
+	if err != nil {
+		WriteErrorResponse(w, http.StatusInternalServerError, []string{"Failed to create device"})
+		return
+	}
+	if err := h.store.Save(device); err != nil {
+		WriteErrorResponse(w, http.StatusInternalServerError, []string{"Failed to save device"})
+		return
+	}
+	response := CreateSignatureDeviceResponse{
+		ID:               device.GetID(),
+		Algorithm:        device.GetAlgorithm(),
+		Label:            req.Label,
+		SignatureCounter: 0,
+	}
+	WriteAPIResponse(w, http.StatusCreated, response)
+}
+
+func (h *DeviceHandler) SignTransaction(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodPost {
+		WriteErrorResponse(w, http.StatusMethodNotAllowed, []string{"Method not allowed"})
+		return
+	}
+
+	device, err := h.store.FindByID(id)
+	if err != nil {
+		WriteErrorResponse(w, http.StatusNotFound, []string{"Device not found"})
+		return
+	}
+	var req SignatureRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		WriteErrorResponse(w, http.StatusBadRequest, []string{"Invalid request payload"})
+		return
+	}
+	if len(req.Data) == 0 || len(req.Data) > 5000 {
+		WriteErrorResponse(w, http.StatusBadRequest, []string{"Invalid data length"})
+		return
+	}
+
+	signature, securedData, err := device.SignData(req.Data)
+	if err != nil {
+		WriteErrorResponse(w, http.StatusInternalServerError, []string{"Failed to sign data"})
+		return
+	}
+	if err := h.store.Update(device); err != nil {
+		fmt.Printf("Failed to update device: %v\n", err)
+		WriteErrorResponse(w, http.StatusInternalServerError, []string{"Failed to update device"})
+		return
+	}
+	response := SignatureResponse{
+		Signature:  signature,
+		SignedData: securedData,
+	}
+	WriteAPIResponse(w, http.StatusOK, response)
+}
+
+func (h *DeviceHandler) GetDeviceDetails(w http.ResponseWriter, r *http.Request, id string) {
+	if r.Method != http.MethodGet {
+		WriteErrorResponse(w, http.StatusMethodNotAllowed, []string{"Method not allowed"})
+		return
+	}
+
+	device, err := h.store.FindByID(id)
+	if err != nil {
+		WriteErrorResponse(w, http.StatusNotFound, []string{"Device not found"})
+		return
+	}
+	response := CreateSignatureDeviceResponse{
+		ID:               device.GetID(),
+		Algorithm:        device.GetAlgorithm(),
+		Label:            device.GetLabel(),
+		SignatureCounter: device.GetSignatureCounter(),
+	}
+	WriteAPIResponse(w, http.StatusOK, response)
+}
+
+func (h *DeviceHandler) ListDevices(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		WriteErrorResponse(w, http.StatusMethodNotAllowed, []string{"Method not allowed"})
+		return
+	}
+
+	devices, err := h.store.FindAll()
+	if err != nil {
+		WriteErrorResponse(w, http.StatusInternalServerError, []string{"Failed to retrieve devices"})
+		return
+	}
+
+	responses := make([]CreateSignatureDeviceResponse, len(devices))
+	for i, device := range devices {
+		responses[i] = CreateSignatureDeviceResponse{
+			ID:               device.GetID(),
+			Algorithm:        device.GetAlgorithm(),
+			Label:            device.GetLabel(),
+			SignatureCounter: device.GetSignatureCounter(),
+		}
+	}
+	WriteAPIResponse(w, http.StatusOK, responses)
+}
+
+func sanitizeLabel(label string) string {
+	label = strings.TrimSpace(label)
+	// Allow only letters, digits, spaces, underscores, and dashes.
+	var sanitized strings.Builder
+	for _, r := range label {
+		if (r >= 'a' && r <= 'z') ||
+			(r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') ||
+			r == ' ' || r == '_' || r == '-' {
+			sanitized.WriteRune(r)
+		}
+	}
+	return sanitized.String()
+}

--- a/signing-service-challenge-go/api/device_test.go
+++ b/signing-service-challenge-go/api/device_test.go
@@ -1,0 +1,323 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fiskaly/coding-challenges/signing-service-challenge/persistence"
+	"github.com/google/uuid"
+)
+
+func setupTestServer() *httptest.Server {
+	store := persistence.NewInMemoryStore()
+	handler := NewDeviceHandler(store)
+
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux)
+
+	return httptest.NewServer(mux)
+}
+
+// Edge Case: Empty Payload
+func TestCreateSignatureDevice_EmptyPayload(t *testing.T) {
+	server := setupTestServer()
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/api/v0/devices", bytes.NewBuffer([]byte("{}")))
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Failed to send request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("Expected status code 400, got %d", resp.StatusCode)
+	}
+}
+
+// Edge Case: Invalid JSON
+func TestCreateSignatureDevice_InvalidJSON(t *testing.T) {
+	server := setupTestServer()
+	defer server.Close()
+
+	payload := []byte(`{"algorithm": "RSA", "label": "Test Device"`) // Missing closing brace
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/api/v0/devices", bytes.NewBuffer(payload))
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Failed to send request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("Expected status code 400, got %d", resp.StatusCode)
+	}
+}
+
+// Edge Case: Unsupported HTTP Method
+func TestCreateSignatureDevice_UnsupportedMethod(t *testing.T) {
+	server := setupTestServer()
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodPut, server.URL+"/api/v0/devices", bytes.NewBuffer([]byte(`{}`)))
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Failed to send request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("Expected status code 405, got %d", resp.StatusCode)
+	}
+}
+
+// Performance Test: High Volume Signing
+func TestSignData_HighVolume(t *testing.T) {
+	server := setupTestServer()
+	defer server.Close()
+
+	payload := []byte(`{"algorithm": "RSA", "label": "High Volume Device"}`)
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/api/v0/devices", bytes.NewBuffer(payload))
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Failed to send request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed to read response body: %v", err)
+	}
+
+	var wrappedResponse struct {
+		Data CreateSignatureDeviceResponse `json:"data"`
+	}
+	if err := json.Unmarshal(body, &wrappedResponse); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	deviceID := wrappedResponse.Data.ID
+
+	var wg sync.WaitGroup
+	numRequests := 1000
+	wg.Add(numRequests)
+
+	start := time.Now()
+
+	for i := 0; i < numRequests; i++ {
+		go func(i int) {
+			defer wg.Done()
+
+			signPayload := []byte(`{"data": "test_data"}`)
+			req, err := http.NewRequest(http.MethodPost, server.URL+"/api/v0/devices/"+deviceID+"/sign", bytes.NewBuffer(signPayload))
+			if err != nil {
+				t.Errorf("Failed to create request: %v", err)
+				return
+			}
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Errorf("Failed to send request: %v", err)
+				return
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("Expected status code 200, got %d", resp.StatusCode)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	elapsed := time.Since(start)
+
+	t.Logf("High volume signing completed in %s", elapsed)
+}
+
+func TestCreateSignatureDevice_LabelSanitization(t *testing.T) {
+	server := setupTestServer()
+	defer server.Close()
+
+	payload := map[string]string{
+		"algorithm": "RSA",
+		"label":     "Test label'); DROP TABLE devices; --",
+	}
+	jsonPayload, _ := json.Marshal(payload)
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/api/v0/devices", bytes.NewBuffer(jsonPayload))
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Failed to send request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("Expected status code 201, got %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed to read response body: %v", err)
+	}
+
+	var wrappedResponse struct {
+		Data CreateSignatureDeviceResponse `json:"data"`
+	}
+	if err := json.Unmarshal(body, &wrappedResponse); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	deviceLabel := wrappedResponse.Data.Label
+	expectedLabel := "Test label DROP TABLE devices --"
+	if deviceLabel != expectedLabel {
+		t.Errorf("Expected label to be '%s', got '%s'", expectedLabel, deviceLabel)
+	}
+}
+
+func TestSignTransaction_InvalidDataLength(t *testing.T) {
+	server := setupTestServer()
+	defer server.Close()
+
+	// Create Device
+	payload := []byte(`{"algorithm": "RSA", "label": "Invalid Data Length Device"}`)
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/api/v0/devices", bytes.NewBuffer(payload))
+	req.Header.Set("Content-Type", "application/json")
+
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	var wrappedResponse struct {
+		Data CreateSignatureDeviceResponse `json:"data"`
+	}
+	json.Unmarshal(body, &wrappedResponse)
+	deviceID := wrappedResponse.Data.ID
+
+	signPayload := []byte(`{"data": ""}`)
+	req, err = http.NewRequest(http.MethodPost, server.URL+"/api/v0/devices/"+deviceID+"/sign", bytes.NewBuffer(signPayload))
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Request failed: %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusBadRequest {
+		t.Errorf("Expected status code 400, got %d", response.StatusCode)
+	}
+}
+
+// GetDeviceDetails: Non-existent Device
+func TestGetDeviceDetails_NotFound(t *testing.T) {
+	server := setupTestServer()
+	defer server.Close()
+	id := uuid.New().String()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/v0/devices/"+id, nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("Expected status code 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestListDevices_Empty(t *testing.T) {
+	server := setupTestServer()
+	defer server.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, server.URL+"/api/v0/devices", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status code 200, got %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed to read response body: %v", err)
+	}
+
+	var wrappedResponse struct {
+		Data []CreateSignatureDeviceResponse `json:"data"`
+	}
+	if err := json.Unmarshal(body, &wrappedResponse); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+	if len(wrappedResponse.Data) != 0 {
+		t.Errorf("Expected empty device list, got %d devices", len(wrappedResponse.Data))
+	}
+
+}
+
+func TestListDevices_Populated(t *testing.T) {
+	server := setupTestServer()
+	defer server.Close()
+
+	payload := []byte(`{"algorithm": "RSA", "label": "Listed Device"}`)
+	req, _ := http.NewRequest(http.MethodPost, server.URL+"/api/v0/devices", bytes.NewBuffer(payload))
+	req.Header.Set("Content-Type", "application/json")
+
+	http.DefaultClient.Do(req)
+
+	req, _ = http.NewRequest(http.MethodGet, server.URL+"/api/v0/devices", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status code 200, got %d", resp.StatusCode)
+	}
+}

--- a/signing-service-challenge-go/crypto/adapter.go
+++ b/signing-service-challenge-go/crypto/adapter.go
@@ -1,0 +1,52 @@
+package crypto
+
+import (
+	"errors"
+)
+
+type AdaptedKeyPair struct {
+	PublicKey  any
+	PrivateKey any
+}
+
+type GeneratorAdapter struct {
+	algorithm string
+}
+
+func NewGeneratorAdapter(algorithm string) (*GeneratorAdapter, error) {
+	switch algorithm {
+	case "RSA":
+		return &GeneratorAdapter{algorithm: "RSA"}, nil
+	case "ECC":
+		return &GeneratorAdapter{algorithm: "ECC"}, nil
+	default:
+		return nil, errors.New("unsupported algorithm")
+	}
+}
+
+func (ga *GeneratorAdapter) Generate() (AdaptedKeyPair, error) {
+	switch ga.algorithm {
+	case "RSA":
+		rsaGen := &RSAGenerator{}
+		keyPair, err := rsaGen.Generate()
+		if err != nil {
+			return AdaptedKeyPair{}, err
+		}
+		return AdaptedKeyPair{
+			PublicKey:  keyPair.Public,
+			PrivateKey: keyPair.Private,
+		}, nil
+	case "ECC":
+		eccGen := &ECCGenerator{}
+		keyPair, err := eccGen.Generate()
+		if err != nil {
+			return AdaptedKeyPair{}, err
+		}
+		return AdaptedKeyPair{
+			PublicKey:  keyPair.Public,
+			PrivateKey: keyPair.Private,
+		}, nil
+	default:
+		return AdaptedKeyPair{}, errors.New("unsupported algorithm")
+	}
+}

--- a/signing-service-challenge-go/crypto/signer.go
+++ b/signing-service-challenge-go/crypto/signer.go
@@ -1,8 +1,108 @@
 package crypto
 
-// Signer defines a contract for different types of signing implementations.
+import (
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+)
+
 type Signer interface {
-	Sign(dataToBeSigned []byte) ([]byte, error)
+	Sign(data []byte) (string, error)
 }
 
-// TODO: implement RSA and ECDSA signing ...
+type RSASigner struct {
+	PrivateKey *rsa.PrivateKey
+}
+
+func NewRSASigner() (*RSASigner, error) {
+	adapter, err := NewGeneratorAdapter("RSA")
+	if err != nil {
+		return nil, err
+	}
+
+	keyPair, err := adapter.Generate()
+	if err != nil {
+		return nil, err
+	}
+
+	privateKey, ok := keyPair.PrivateKey.(*rsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("invalid RSA private key type")
+	}
+
+	return &RSASigner{PrivateKey: privateKey}, nil
+}
+
+func (s *RSASigner) Sign(data []byte) (string, error) {
+	hashed := sha256.Sum256(data)
+	signature, err := rsa.SignPKCS1v15(nil, s.PrivateKey, 0, hashed[:])
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(signature), nil
+}
+
+type ECCSigner struct {
+	PrivateKey *ecdsa.PrivateKey
+}
+
+func NewECCSigner() (*ECCSigner, error) {
+	adapter, err := NewGeneratorAdapter("ECC")
+	if err != nil {
+		return nil, err
+	}
+
+	keyPair, err := adapter.Generate()
+	if err != nil {
+		return nil, err
+	}
+
+	privateKey, ok := keyPair.PrivateKey.(*ecdsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("invalid ECC private key type")
+	}
+
+	return &ECCSigner{PrivateKey: privateKey}, nil
+}
+
+func (s *ECCSigner) Sign(data []byte) (string, error) {
+	hashed := sha256.Sum256(data)
+	r, sSig, err := ecdsa.Sign(nil, s.PrivateKey, hashed[:])
+	if err != nil {
+		return "", err
+	}
+	signature := append(r.Bytes(), sSig.Bytes()...)
+	return base64.StdEncoding.EncodeToString(signature), nil
+}
+
+func NewSignerFactory(algorithm string) (Signer, error) {
+	switch algorithm {
+	case "RSA":
+		return NewRSASigner()
+	case "ECC":
+		return NewECCSigner()
+	default:
+		return nil, errors.New("unsupported signing algorithm")
+	}
+}
+
+func NewSignerWithKey(algorithm string, privateKey any) (Signer, error) {
+	switch algorithm {
+	case "RSA":
+		rsaKey, ok := privateKey.(*rsa.PrivateKey)
+		if !ok {
+			return nil, errors.New("invalid RSA private key")
+		}
+		return &RSASigner{PrivateKey: rsaKey}, nil
+	case "ECC":
+		eccKey, ok := privateKey.(*ecdsa.PrivateKey)
+		if !ok {
+			return nil, errors.New("invalid ECC private key")
+		}
+		return &ECCSigner{PrivateKey: eccKey}, nil
+	default:
+		return nil, errors.New("unsupported signing algorithm")
+	}
+}

--- a/signing-service-challenge-go/domain/device.go
+++ b/signing-service-challenge-go/domain/device.go
@@ -1,3 +1,85 @@
 package domain
 
-// TODO: signature device domain model ...
+import (
+	"encoding/base64"
+	"strconv"
+	"sync"
+
+	"github.com/fiskaly/coding-challenges/signing-service-challenge/crypto"
+	"github.com/google/uuid"
+)
+
+type SignatureDevice struct {
+	id               string
+	label            string
+	algorithm        string
+	publicKey        any
+	privateKey       any
+	signatureCounter int32
+	lastSignature    string
+	mu               sync.Mutex
+}
+
+func CreateNewDevice(algorithm, label string) (*SignatureDevice, error) {
+	adapter, err := crypto.NewGeneratorAdapter(algorithm)
+	if err != nil {
+		return nil, err
+	}
+	keyPair, err := adapter.Generate()
+	if err != nil {
+		return nil, err
+	}
+	id := uuid.New().String()
+	return &SignatureDevice{
+		id:               id,
+		label:            label,
+		algorithm:        algorithm,
+		publicKey:        keyPair.PublicKey,
+		privateKey:       keyPair.PrivateKey,
+		signatureCounter: 0,
+		lastSignature:    base64.StdEncoding.EncodeToString([]byte(id)),
+	}, nil
+}
+
+func (d *SignatureDevice) SignData(data string) (string, string, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	securedData := d.GetSecuredDataToBeSigned(data)
+	signer, err := crypto.NewSignerWithKey(d.algorithm, d.privateKey)
+	if err != nil {
+		return "", "", err
+	}
+
+	signature, err := signer.Sign([]byte(securedData))
+	if err != nil {
+		return "", "", err
+	}
+
+	d.lastSignature = signature
+	d.signatureCounter++
+	return signature, securedData, nil
+}
+
+func (d *SignatureDevice) GetSecuredDataToBeSigned(dataToBeSigned string) string {
+	counterStr := strconv.Itoa(int(d.signatureCounter))
+	return counterStr + "_" + dataToBeSigned + "_" + d.lastSignature
+}
+
+func (d *SignatureDevice) GetSignatureCounter() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return int(d.signatureCounter)
+}
+
+func (d *SignatureDevice) GetID() string {
+	return d.id
+}
+
+func (d *SignatureDevice) GetAlgorithm() string {
+	return d.algorithm
+}
+
+func (d *SignatureDevice) GetLabel() string {
+	return d.label
+}

--- a/signing-service-challenge-go/domain/device_test.go
+++ b/signing-service-challenge-go/domain/device_test.go
@@ -1,0 +1,84 @@
+package domain
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestCreateNewDevice_Valid(t *testing.T) {
+	device, err := CreateNewDevice("RSA", "Test Device")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if device.GetAlgorithm() != "RSA" {
+		t.Errorf("Expected algorithm to be 'RSA', got %s", device.GetAlgorithm())
+	}
+
+	if device.GetLabel() != "Test Device" {
+		t.Errorf("Expected label to be 'Test Device', got %s", device.GetLabel())
+	}
+
+	if device.GetSignatureCounter() != 0 {
+		t.Errorf("Expected signature counter to be 0, got %d", device.GetSignatureCounter())
+	}
+}
+
+func TestCreateNewDevice_InvalidAlgorithm(t *testing.T) {
+	_, err := CreateNewDevice("InvalidAlgo", "Test Device")
+	if err == nil {
+		t.Fatalf("Expected error for invalid algorithm, got nil")
+	}
+}
+
+func TestSignData_Valid(t *testing.T) {
+	device, err := CreateNewDevice("RSA", "Test Device")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	signature, securedData, err := device.SignData("test_data")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if signature == "" {
+		t.Errorf("Expected non-empty signature, got empty string")
+	}
+
+	if !strings.Contains(securedData, "test_data") {
+		t.Errorf("Expected secured data to contain 'test_data', got %s", securedData)
+	}
+
+	if device.GetSignatureCounter() != 1 {
+		t.Errorf("Expected signature counter to be 1, got %d", device.GetSignatureCounter())
+	}
+}
+
+func TestSignData_Concurrency(t *testing.T) {
+	device, err := CreateNewDevice("RSA", "Concurrent Device")
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	var wg sync.WaitGroup
+	numRoutines := 100
+	wg.Add(numRoutines)
+
+	for i := 0; i < numRoutines; i++ {
+		go func() {
+			defer wg.Done()
+			_, _, err := device.SignData("concurrent_data")
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if device.GetSignatureCounter() != numRoutines {
+		t.Errorf("Expected signature counter to be %d, got %d", numRoutines, device.GetSignatureCounter())
+	}
+}

--- a/signing-service-challenge-go/go.mod
+++ b/signing-service-challenge-go/go.mod
@@ -1,3 +1,5 @@
 module github.com/fiskaly/coding-challenges/signing-service-challenge
 
 go 1.20
+
+require github.com/google/uuid v1.6.0

--- a/signing-service-challenge-go/go.sum
+++ b/signing-service-challenge-go/go.sum
@@ -1,0 +1,2 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/signing-service-challenge-go/main.go
+++ b/signing-service-challenge-go/main.go
@@ -8,11 +8,13 @@ import (
 
 const (
 	ListenAddress = ":8080"
-	// TODO: add further configuration parameters here ...
+	ReadTimeout   = 5
+	WriteTimeout  = 10
+	IdleTimeout   = 120
 )
 
 func main() {
-	server := api.NewServer(ListenAddress)
+	server := api.NewServer(ListenAddress, ReadTimeout, WriteTimeout, IdleTimeout)
 
 	if err := server.Run(); err != nil {
 		log.Fatal("Could not start server on ", ListenAddress)

--- a/signing-service-challenge-go/persistence/inmemory.go
+++ b/signing-service-challenge-go/persistence/inmemory.go
@@ -1,3 +1,61 @@
 package persistence
 
-// TODO: in-memory persistence ...
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/fiskaly/coding-challenges/signing-service-challenge/domain"
+)
+
+type InMemoryStore struct {
+	devices map[string]*domain.SignatureDevice
+	mu      sync.RWMutex
+}
+
+func NewInMemoryStore() *InMemoryStore {
+	return &InMemoryStore{
+		devices: make(map[string]*domain.SignatureDevice),
+	}
+}
+
+func (s *InMemoryStore) Save(device *domain.SignatureDevice) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.devices[device.GetID()]; exists {
+		return errors.New("device with this ID already exists")
+	}
+	s.devices[device.GetID()] = device
+	return nil
+}
+
+func (s *InMemoryStore) FindByID(id string) (*domain.SignatureDevice, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	device, exists := s.devices[id]
+	if !exists {
+		return nil, errors.New("device not found")
+	}
+	return device, nil
+}
+
+func (s *InMemoryStore) FindAll() ([]*domain.SignatureDevice, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	devices := make([]*domain.SignatureDevice, 0, len(s.devices))
+	for _, device := range s.devices {
+		devices = append(devices, device)
+	}
+	return devices, nil
+}
+
+func (s *InMemoryStore) Update(device *domain.SignatureDevice) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.devices[device.GetID()]; !exists {
+		return fmt.Errorf("device not found")
+	}
+	// Avoid copying the device (and its embedded mutex)
+	s.devices[device.GetID()] = device
+	return nil
+}

--- a/signing-service-challenge-go/persistence/storage.go
+++ b/signing-service-challenge-go/persistence/storage.go
@@ -1,0 +1,11 @@
+package persistence
+
+import "github.com/fiskaly/coding-challenges/signing-service-challenge/domain"
+
+// Storage interface for SignatureDevice management
+type Storage interface {
+	Save(device *domain.SignatureDevice) error
+	FindByID(id string) (*domain.SignatureDevice, error)
+	FindAll() ([]*domain.SignatureDevice, error)
+	Update(device *domain.SignatureDevice) error
+}


### PR DESCRIPTION
### Signature Service Implementation

This PR implements the Signature Service as specified in the coding challenge. It includes:
- Endpoint to create a signature device with a unique ID, label, and chosen algorithm (ECC or RSA).
- Endpoint to sign transaction data securely with the current signature counter and last signature.
- Retrieval endpoints to list and get details of signature devices.

### Key Features:
- Signature counter is strictly monotonically increasing without gaps.
- Signing mechanism supports both ECC and RSA and is designed for easy extension.
- In-memory storage used with a structure that can be easily adapted to a relational database.
- Concurrency-safe design to handle multiple clients accessing the same resources.

### Makefile Included:
This project includes a Makefile to streamline development workflows:
- `make build`: Compiles the application into an executable named `signing-service-challenge`.
- `make test`: Runs all unit tests with the `-race` flag for race condition detection.
- `make run`: Builds and runs the application.
- `make clean`: Removes the compiled executable.

### How to Test:
- Build and run using the Makefile commands:
    ```bash
    make build
    make run
    ```
- Run all unit tests:
    ```bash
    make test
    ```
- Endpoints can be tested with Postman or cURL.

---

Thank you for the opportunity to participate in this challenge. I look forward to any feedback or questions!